### PR TITLE
NEW Adds possibility to use existing transaction as template to new

### DIFF
--- a/src/App/Instances/CreateTransactionForm.jsx
+++ b/src/App/Instances/CreateTransactionForm.jsx
@@ -6,6 +6,7 @@ import CreateTransactionComponent from '../../components/CreateTransactionCompon
 
 export default function CreateTransactionComponentInstance({state, ajaxInjections}) {
   const createTransaction = R.view(AjaxInjectionsLens.createTransaction, ajaxInjections);
+  const getTransaction = R.view(AjaxInjectionsLens.getTransaction, ajaxInjections);
   const accounts = R.view(AppLens.accounts, state);
   const currencies = R.view(AppLens.currencies, state);
   if (R.isNil(accounts) || R.isNil(currencies)) {
@@ -14,6 +15,7 @@ export default function CreateTransactionComponentInstance({state, ajaxInjection
   return (
     <CreateTransactionComponent
       createTransaction={createTransaction}
+      getTransaction={getTransaction}
       accounts={accounts}
       currencies={currencies} />
   );

--- a/src/components/CreateTransactionComponent.jsx
+++ b/src/components/CreateTransactionComponent.jsx
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
+import * as RU from '../ramda-utils';
+import * as R from 'ramda';
 import TransactionForm from './TransactionForm.jsx';
-
+import TransactionPicker from './TransactionPicker.jsx';
+import InputWrapper, { propLens as InputWrapperLens } from './InputWrapper';
 
 /**
  * A wrapper around TransactionForm used to create a Transaction.
@@ -11,6 +14,7 @@ export default class CreateTransactionComponent extends Component {
    * @param {object} props
    * @param {function(TransactionSpec): Promise} createTransaction - A function
    *   that performs the creation of a Transaction from a TransactionSpec.
+   * @param getTransaction - A function that fetches a transaction from a pk.
    */
   constructor(props) {
     super(props);
@@ -25,7 +29,15 @@ export default class CreateTransactionComponent extends Component {
     return this.props.createTransaction(transactionSpec);
   }
 
+  renderTemplatePicker = () => (
+    <TemplatePicker
+      getTransaction={this.props.getTransaction}
+      onPicked={this.handleTransactionFormChange}
+    />
+  )
+
   render() {
+    const templatePicker = this.renderTemplatePicker();
     return (
       <TransactionForm
         title="Create Transaction Form"
@@ -33,8 +45,41 @@ export default class CreateTransactionComponent extends Component {
         currencies={this.props.currencies}
         onChange={this.handleTransactionFormChange}
         onSubmit={this.handleTransactionFormSubmit}
-        value={this.state.transactionSpec} />
+        value={this.state.transactionSpec}
+        templatePicker={templatePicker}
+      />
     );
   }
   
 }
+
+
+/**
+ * A custom instance of TransactionPicker used by the CreateTransactionComponent to
+ * allow users to pick a template.
+ * @param getTransaction - A function that fetches a transaction from a pk.
+ */
+export function TemplatePicker({getTransaction, onPicked}) {
+  const onTransactionPicked = R.pipe(transactionToTemplateSpec, onPicked);
+  const picker = (
+    <TransactionPicker
+      onPicked={onTransactionPicked}
+      getTransaction={getTransaction} />
+  );
+  const inputWrapperProps = RU.objFromPairs(
+    InputWrapperLens.label, TEMPLATE_PICKER_LABEL,
+    InputWrapperLens.content, picker,
+  );
+  return <InputWrapper {...inputWrapperProps} />;;
+}
+
+/**
+ * Adapts a picked Transaction into a TransactionSpec, serving as a template for the
+ * picked transaction.
+ */
+export function transactionToTemplateSpec(transaction) {
+  return R.pipe(R.dissoc('date'), R.dissoc('pk'))(transaction);
+}
+
+// Constants
+export const TEMPLATE_PICKER_LABEL = "Use transaction as Template";

--- a/src/components/EditTransactionComponent.jsx
+++ b/src/components/EditTransactionComponent.jsx
@@ -3,7 +3,8 @@ import TransactionPicker from './TransactionPicker';
 import TransactionForm from './TransactionForm';
 import ErrorMessage from './ErrorMessage.jsx';
 import SuccessMessage from './SuccessMessage.jsx';
-import { getSpecFromTransaction } from '../utils.jsx';
+import { getSpecFromTransaction, createTitle } from '../utils.jsx';
+
 
 /**
  * A component used to edit a transaction.
@@ -71,8 +72,10 @@ export default class EditTransactionComponent extends Component {
 
   render() {
     const { getTransaction } = this.props;
+    const {title="Edit Transaction Form"} = this.props;
     return (
       <div>
+        {createTitle(title)}
         <TransactionPicker
           getTransaction={getTransaction}
           onPicked={this.setTransaction} />

--- a/src/components/TransactionForm.jsx
+++ b/src/components/TransactionForm.jsx
@@ -21,6 +21,9 @@ export default class TransactionForm extends Component {
    *   transaction data and performs the action. Must return an
    *   axios-like Promise.
    * @param {string} props.title
+   * @param templatePicker - An optional component that is displayed to the user so it can
+   *                         select a template. This component is rendered as-is, and any
+   *                         logic must be implemented by the parent.
    * @param {Account[]} props.accounts - An array with all accounts.
    * @param {Currency[]} props.currencies - An array with all currencies.
    * @param {TransactionSpec} [props.value] - The value.
@@ -88,11 +91,12 @@ export default class TransactionForm extends Component {
   }
 
   render() {
-    const { title="" } = this.props;
+    const { title="", templatePicker } = this.props;
     return (
       <div className="form-div">
+        {createTitle(title)}
+        {templatePicker}
         <form onSubmit={this.handleSubmit}>
-          {createTitle(title)}
           {this.renderReferenceInput()}
           {this.renderDescriptionInput()}
           {this.renderDateInput()}

--- a/src/components/TransactionPicker.jsx
+++ b/src/components/TransactionPicker.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { createTitle } from '../utils';
 
 /**
  * A Component that prompts the user to select a Transaction.
@@ -8,9 +7,9 @@ export default class TransactionPicker extends Component {
 
 /**
  * @param {object} props
- * @param {string} [props.title] - The title.
  * @param {fn(number): Promise<Transaction>} props.getTransaction - A function that
  *   maps a pk to a promise with a Transaction.
+ * @param props.onPicked - A callback function called with the picked transaction.
  */
   constructor(props) {
     super(props);
@@ -31,11 +30,9 @@ export default class TransactionPicker extends Component {
   }
 
   render() {
-    const {title="Edit Transaction Form"} = this.props;
     return (
       <form onSubmit={this.handleSubmit}>
-        {createTitle(title)}
-        pk:<input name="pk" type="number" onChange={this.handlePkChange} />
+        <input placeholder="pk" name="pk" type="number" onChange={this.handlePkChange} />
         <input type="submit"/>
       </form>
     );

--- a/src/components/__tests__/CreateTransactionComponent.spec.jsx
+++ b/src/components/__tests__/CreateTransactionComponent.spec.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { AccountFactory, CurrencyFactory, TransactionFactory } from '../../testUtils.jsx';
 import { mount } from 'enzyme';
-import CreateTransactionComponent from '../CreateTransactionComponent';
+import CreateTransactionComponent, * as sut from '../CreateTransactionComponent';
 import TransactionForm from '../TransactionForm.jsx';
 import { getSpecFromTransaction } from '../../utils.jsx';
 import sinon from 'sinon';
+import InputWrapper, { propLens as InputWrapperLens } from '../InputWrapper';
+import * as R from 'ramda';
 
 function mountCreateTransactionComponent(opts) {
   const { accounts=AccountFactory.buildList(3) } = opts;
@@ -39,6 +41,10 @@ describe('CreateTransactionComponent', () => {
       component.update();
       expect(component.state().transactionSpec).toBe(transactionSpec);
     });
+    it('Passes an instance of TemplatePicker to TransactionForm', () => {
+      expect(component.find(TransactionForm).props().templatePicker.type.name)
+        .toEqual('TemplatePicker');
+    });
   });
 
   describe('Submitting...', () => {
@@ -55,4 +61,32 @@ describe('CreateTransactionComponent', () => {
     });
   });
 
+});
+
+
+describe('TemplatePicker', () => {
+
+  let onPicked, component;
+
+  beforeEach(() => {
+    onPicked = sinon.fake();
+    component = mount(<sut.TemplatePicker onPicked={onPicked} />);
+  });
+
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  it('Renders an InputWrapper with label', () => {
+    expect(R.view(InputWrapperLens.label, component.find(InputWrapper).props()))
+      .toEqual(sut.TEMPLATE_PICKER_LABEL);
+  });
+
+  it('Calls onPicked after transforming to template spec', () => {
+    const transaction = {date: "2020-01-01"};
+    component.find('TransactionPicker').props().onPicked(transaction);
+    expect(onPicked.args).toHaveLength(1);
+    expect(onPicked.args[0]).toEqual([{}]);
+  });
+  
 });

--- a/src/components/__tests__/EditTransactionComponent.spec.jsx
+++ b/src/components/__tests__/EditTransactionComponent.spec.jsx
@@ -23,13 +23,15 @@ function mountEditTransactionComponent({
   updateTransaction = (() => Promise.resolve({})),
   accounts=[],
   currencies=[],
+  title=""
 }) {
   return mount(
     <EditTransactionComponent
       getTransaction={getTransaction}
       updateTransaction={updateTransaction}
       accounts={accounts}
-      currencies={currencies} />
+      currencies={currencies}
+      title={title} />
   );
 }
 
@@ -37,6 +39,8 @@ describe('EditTransactionComponent()', () => {
 
   let transaction, transactionPromise, getTransaction, editTransactionComponent,
       updateTransaction, accounts, currencies;
+
+  const title = "Title!";
 
   beforeEach(() => {
     accounts = AccountFactory.buildList(3);
@@ -46,10 +50,15 @@ describe('EditTransactionComponent()', () => {
     getTransaction = () => transactionPromise;
     updateTransaction = sinon.fake.resolves();
     editTransactionComponent = mountEditTransactionComponent(
-      { getTransaction, updateTransaction, accounts, currencies }
+      { getTransaction, updateTransaction, accounts, currencies, title }
     );
   });
 
+  it('Renders with title', () => {
+    const span = editTransactionComponent.find('span.titleSpan');
+    expect(span.html()).toContain(title);
+  });
+  
   describe('TransactionPicker child...', () => {
     it('Pass getTransaction function as prop', () => {
       expect(editTransactionComponent.find(TransactionPicker).props().getTransaction)

--- a/src/components/__tests__/TransactionForm.spec.jsx
+++ b/src/components/__tests__/TransactionForm.spec.jsx
@@ -27,6 +27,7 @@ function mountTransactionForm(
     onSubmit=(()=>Promise.resolve({})),
     onChange=sinon.fake(),
     accounts=[],
+    templatePicker=undefined
   }={}
 ) {
   return mount(
@@ -35,7 +36,9 @@ function mountTransactionForm(
       title={title}
       onSubmit={onSubmit}
       onChange={onChange}
-      accounts={accounts} />
+      accounts={accounts}
+      templatePicker={templatePicker}
+    />
   );
 }
 
@@ -67,6 +70,12 @@ describe('TransactionForm', () => {
       const title = "aloha";
       const formComponent = mountTransactionForm({title});
       expect(formComponent.find("span.titleSpan").first().html()).toContain(title);
+    });
+
+    it('Mounts with templatePicker if given', () => {
+      function TemplatePicker() { return <span>{"FOO"}</span>; };
+      const formComponent = mountTransactionForm({templatePicker: <TemplatePicker />});
+      expect(formComponent.find(TemplatePicker)).toHaveLength(1);
     });
 
     it('Mounts with all inputs and empty strings if no value', () => {

--- a/src/components/__tests__/TransactionPicker.spec.jsx
+++ b/src/components/__tests__/TransactionPicker.spec.jsx
@@ -9,10 +9,6 @@ describe('TransactionPicker', () => {
   describe('Rendering...', () => {
     const titleStr = "Edit Transaction!";
     const picker = mount(<TransactionPicker title={titleStr} />);;
-    it('Renders with title', () => {
-      const span = picker.find('span.titleSpan');
-      expect(span.html()).toContain(titleStr);
-    });
     it('Renders input for pk', () => {
       const inp = picker.find('input[name="pk"]');
       expect(inp).toHaveLength(1);


### PR DESCRIPTION
Users can now use a TransactionPicker to select an existing
transaction that they would like to use as a template to a new
transaction.