### PR TITLE
NEW Adds search term for Transaction Table

### DIFF
--- a/src/App/Instances/__tests__/TransactionTable.spec.jsx
+++ b/src/App/Instances/__tests__/TransactionTable.spec.jsx
@@ -6,6 +6,7 @@ import * as RU from '../../../ramda-utils';
 import TransactionTableInstance from '../TransactionTable';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import ReactTestUtils from 'react-dom/test-utils';
 
 
 describe('TransactionTable', () => {
@@ -38,7 +39,7 @@ describe('TransactionTable', () => {
     expect(resp).toEqual(<p>Loading...</p>);
   });
 
-  it('Finished loading', () => {
+  it('Finished loading', async () => {
     const currencies = CurrencyFactory.buildList(2);
     const accounts = AccountFactory.buildList(2);
     const state = RU.objFromPairs(
@@ -53,13 +54,16 @@ describe('TransactionTable', () => {
       AppLens.currencies, getCurrency,
     );
     const ajaxInjections = {getPaginatedTransactions};
-    const resp = mount(TransactionTableInstance({ state, stateGetters, ajaxInjections }));
-    const transTable = resp.find("TransactionTable");
 
-    expect(transTable).toHaveLength(1);
-    expect(transTable.props().getCurrency).toBe(getCurrency);
-    expect(transTable.props().getAccount).toBe(getAccount);
-    expect(transTable.props().getPaginatedTransactions).toBe(getPaginatedTransactions);
+    await ReactTestUtils.act(async () => {
+      const resp = mount(TransactionTableInstance({ state, stateGetters, ajaxInjections }));
+      const transTable = resp.find("TransactionTable");
+
+      expect(transTable).toHaveLength(1);
+      expect(transTable.props().getCurrency).toBe(getCurrency);
+      expect(transTable.props().getAccount).toBe(getAccount);
+      expect(transTable.props().getPaginatedTransactions).toBe(getPaginatedTransactions);
+    });
   });
 
 });

--- a/src/__tests__/ajax.spec.js
+++ b/src/__tests__/ajax.spec.js
@@ -99,6 +99,18 @@ describe('Test ajax', () => {
         expect(result.items).toEqual(transactions);
       });
 
+      it('With description and reference', async () => {
+        const transactions = TransactionFactory.buildList(2);
+        const rawTransactionsResponse = R.pipe(
+          R.map(remapKeys({movements: "movements_specs"})),
+          R.map(R.evolve({date: d => d.format("YYYY-MM-DD")}))
+        )(transactions);
+        const axiosMock = getAxiosMock({ transactions: rawTransactionsResponse });
+        const args = {description: "Foo", reference: "Bar"};
+        const result = await AjaxGetPaginatedTransactions.run(axiosMock)(args);
+        assertCalledWithUrl(axiosMock, "/transactions/?page=1&page_size=20&description=Foo&reference=Bar");
+        expect(result.items).toEqual(transactions);
+      });
     });
 
     describe('AjaxGetPaginatedTransactions', () => {
@@ -110,6 +122,12 @@ describe('Test ajax', () => {
           .toEqual("/transactions/?page=10&page_size=20");
         expect(sut.AjaxGetPaginatedTransactions._makeUrl({pageSize: 100}))
           .toEqual("/transactions/?page=1&page_size=100");
+        expect(sut.AjaxGetPaginatedTransactions._makeUrl({description: "Foo"}))
+          .toEqual("/transactions/?page=1&page_size=20&description=Foo");
+        expect(sut.AjaxGetPaginatedTransactions._makeUrl({reference: "Foo"}))
+          .toEqual("/transactions/?page=1&page_size=20&reference=Foo");
+        expect(sut.AjaxGetPaginatedTransactions._makeUrl({reference: "A", description: "B"}))
+          .toEqual("/transactions/?page=1&page_size=20&description=B&reference=A");
       });
 
       describe('_parseResponse', () => {

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -89,9 +89,9 @@ export const transactionSpecToRequestParams = R.pipe(
  */
 export const AjaxGetPaginatedTransactions = {
 
-  run: (axios) => ({page=0, pageSize=20}) => makeRequest({
+  run: (axios) => ({page=0, pageSize=20, description=null, reference=null}) => makeRequest({
     axios,
-    url: AjaxGetPaginatedTransactions._makeUrl({page, pageSize}),
+    url: AjaxGetPaginatedTransactions._makeUrl({page, pageSize, description, reference}),
     parseResponseData: AjaxGetPaginatedTransactions._parseResponse({page, pageSize})
   }),
 
@@ -110,7 +110,12 @@ export const AjaxGetPaginatedTransactions = {
   /**
    * Makes an url given some pagination options.
    */
-  _makeUrl: ({page, pageSize}) => `/transactions/?page=${page+1||1}&page_size=${pageSize||20}`,
+  _makeUrl: ({page, pageSize, description, reference}) => {
+    let result = `/transactions/?page=${page+1||1}&page_size=${pageSize||20}`;
+    if (description) { result = `${result}&description=${description}`; }
+    if (reference) { result = `${result}&reference=${reference}`; }
+    return result;
+  }
   
 };
 

--- a/src/components/__tests__/TransactionTable.spec.jsx
+++ b/src/components/__tests__/TransactionTable.spec.jsx
@@ -9,17 +9,21 @@ import { getSourceAccsPks, getTargetAccsPks, newGetter, memoizeSimple } from '..
 import sinon from 'sinon';
 import ReactTable from 'react-table';
 import moment from 'moment';
+import ReactTestUtils from 'react-dom/test-utils';
 
 describe('Testing TransactionTable', () => {
 
-  let mountTransactionTable = (transactions, getCurrency, getAccount) => {
+  let mountTransactionTable = (transactions, getCurrency, getAccount, getPaginatedTransactions) => {
     getCurrency = getCurrency || (() => CurrencyFactory.build());
     getAccount = getAccount || (() => AccountFactory.build());
+    getPaginatedTransactions = getPaginatedTransactions || (() => Promise.resolve({}));
     return mount(
       <TransactionTable
         transactions_={transactions}
         getCurrency={getCurrency}
-        getAccount={getAccount} />
+        getAccount={getAccount}
+        getPaginatedTransactions={getPaginatedTransactions}
+      />
     );
   };
 
@@ -31,14 +35,24 @@ describe('Testing TransactionTable', () => {
     sinon.restore();
   });
 
-  it('Renders a ReactTable with props from ReactTableProps', () => {
+  it('Renders a ReactTable with props from ReactTableProps', async () => {
     let fakeGen = ({getCurrency, getAccount}, transactions) => { return {columns: []}; };
     sinon.stub(sut.ReactTableProps, 'gen').callsFake(fakeGen);
 
-    let component = mountTransactionTable();
+    await ReactTestUtils.act(async () => {
+      let component = mountTransactionTable();
+      
+      expect(component.find(ReactTable).props().data).toEqual([]);
+      expect(component.find(ReactTable).props().columns).toEqual([]);
+    });
+  });
+
+  it('Passes a header instance to the TableCore', async () => {
     
-    expect(component.find(ReactTable).props().data).toEqual([]);
-    expect(component.find(ReactTable).props().columns).toEqual([]);
+    await ReactTestUtils.act(async () => {
+      const header = mountTransactionTable().find(sut.TransactionTableCore).props().header;
+      expect(header.props.className).toEqual('transaction-table-header');
+    });
   });
 
   describe('extractQuantityMoved', () => {
@@ -93,6 +107,23 @@ describe('Testing TransactionTable', () => {
   });
 });
 
+describe('TransactionTableCore', () => {
+
+  function mountComponent(props) {
+    const parsedProps = {pageState: [0, ()=>{}], pageSizeState: [0, ()=>{}], ...props};
+    parsedProps.paginatedTransactions = props.paginatedTransactions || { items: [] }; 
+    return mount(<sut.TransactionTableCore {...parsedProps} />);
+  }
+
+  it('Mounts header if defined', () => {
+    const Header = () => <div>{"Foo"}</div>;
+    const header = <Header />;
+    const component = mountComponent({header});
+    expect(component.find(Header)).toHaveLength(1);
+  });
+
+});
+
 describe('Testing ReactTableProps', () => {
 
   /**
@@ -102,8 +133,16 @@ describe('Testing ReactTableProps', () => {
 
   describe('.gen()', () => {
 
+    /**
+     * Helpers that mounts with smart defaults
+     */
+    function gen(opts, paginatedTransactions) {
+      const optsWithDefault = {pageState: [0, ()=>{}], pageSizeState: [0, ()=>{}], ...opts};
+      return sut.ReactTableProps.gen(optsWithDefault, paginatedTransactions);
+    }
+
     it('id column', () => {
-      const idCol = selectColumnById("pk", sut.ReactTableProps.gen({}, []));
+      const idCol = selectColumnById("pk", gen({}, []));
       expect(idCol.id).toEqual("pk");
       expect(idCol.Header).toEqual("Pk");
       expect(idCol.accessor({"pk": 222})).toEqual(222);
@@ -111,14 +150,14 @@ describe('Testing ReactTableProps', () => {
     });
 
     it('description column', () => {
-      const col = selectColumnById("description", sut.ReactTableProps.gen({}, []));
+      const col = selectColumnById("description", gen({}, []));
       expect(col.id).toEqual("description");
       expect(col.Header).toEqual("Description");
       expect(col.accessor({description: "FOO"})).toEqual("FOO");
     });
 
     it('date column', () => {
-      const col = selectColumnById("date", sut.ReactTableProps.gen({}, []));
+      const col = selectColumnById("date", gen({}, []));
       expect(col.id).toEqual("date");
       expect(col.Header).toEqual("Date");
       expect(col.accessor({date: moment("2019-01-01")})).toEqual("2019-01-01");
@@ -128,7 +167,7 @@ describe('Testing ReactTableProps', () => {
     it('quantity column', () => {
       const getCurrency = () => CurrencyFactory.build();
       const movements = MovementFactory.buildList(2);
-      const col = selectColumnById("quantity", sut.ReactTableProps.gen({getCurrency}, []));
+      const col = selectColumnById("quantity", gen({getCurrency}, []));
 
       expect(col.id).toEqual("quantity");
       expect(col.Header).toEqual("Quantity");
@@ -140,7 +179,7 @@ describe('Testing ReactTableProps', () => {
       const movements = MovementFactory.buildList(2);
       const account = AccountFactory.build();
       const getAccount = () => account;
-      const col = selectColumnById("accounts", sut.ReactTableProps.gen({getAccount}, []));
+      const col = selectColumnById("accounts", gen({getAccount}, []));
 
       expect(col.id).toEqual("accounts");
       expect(col.Header).toEqual("Accounts");
@@ -148,23 +187,41 @@ describe('Testing ReactTableProps', () => {
     });
 
     it('Reads pages from paginatedTransactions', () => {
-      const result = sut.ReactTableProps.gen({}, {pageCount: 10});
+      const result = gen({}, {pageCount: 10});
       expect(result.pages).toEqual(10);
     });
 
     it('Defaults pages to -1', () => {
-      const result = sut.ReactTableProps.gen({}, {});
+      const result = gen({}, {});
       expect(result.pages).toEqual(-1);
     });
 
     it('Reads data from paginatedTransactions', () => {
-      const result = sut.ReactTableProps.gen({}, {items: [{id: 1}]});
+      const result = gen({}, {items: [{id: 1}]});
       expect(result.data).toEqual([{id: 1}]);
     });
 
     it('Defaults data to empty array', () => {
-      const result = sut.ReactTableProps.gen({}, {});
+      const result = gen({}, {});
       expect(result.data).toEqual([]);
+    });
+
+    it('Passes page and callback from pageState', () => {
+      const page = 2;
+      const setPage = () => {};
+      const pageState = [page, setPage];
+      const result = gen({pageState}, {});
+      expect(result.page).toEqual(2);
+      expect(result.onPageChange).toEqual(setPage);
+    });
+
+    it('Passes pageSize and callback from pageSizeState', () => {
+      const pageSize = 2;
+      const setPageSize = () => {};
+      const pageSizeState = [pageSize, setPageSize];
+      const result = gen({pageSizeState}, {});
+      expect(result.pageSize).toEqual(2);
+      expect(result.onPageSizeChange).toEqual(setPageSize);
     });
   });
   
@@ -175,32 +232,111 @@ describe('TransactionFetcher', () => {
   beforeEach(() => { sinon.restore(); });
   afterEach(() => { sinon.restore(); });
 
-  describe('fetch', () => {
+  describe('extractArgsFromReactTableState', () => {
 
-    it('getPaginatedTransactions and returns', () => {
-      const opts = {page: 1, pageSize: 2};
-      const getPaginatedTransactions = R.identity;
-      const result = sut.TransactionFetcher.fetch({getPaginatedTransactions})(opts);
-      expect(result).toEqual(opts);
+    it('Gets page and page size', () => {
+      const reactTableState = {page: 1, pageSize: 2, foo: "BAR"};
+      const result = sut.TransactionFetcher.extractArgsFromReactTableState(reactTableState);
+      expect(result).toEqual({page: 1, pageSize: 2});
     });
     
   });
 
-  describe('fetchFromReactTableState', () => {
+  describe('withSearchTerm', () => {
 
-    it('Calls fetch with page and pageSize', () => {
-      const fetchStub = sinon.stub(sut.TransactionFetcher, 'fetch').callsFake(() => "FOO");
-      const getPaginatedTransactions = R.identity;
-      const reactTableState = {page: 1, pageSize: 2};
+    const args = {page: 1, pageSize: 2};
+    
+    it('When is empty string, does nothing', () => {
+      const searchTerm = "";
+      const result = sut.TransactionFetcher.withSearchTerm(searchTerm)(args);
+      expect(result).toEqual(args);
+    });
 
-      const result = sut.TransactionFetcher.fetchFromReactTableState(
-        {getPaginatedTransactions},
-        reactTableState
-      );
-      
-      expect(result).toEqual("FOO");
-      expect(fetchStub.args).toHaveLength(1);
-      expect(fetchStub.args[0]).toEqual([{getPaginatedTransactions}, {page: 1, pageSize: 2}]);
+    it('When is not string, adds it', () => {
+      const searchTerm = "Foo";
+      const result = sut.TransactionFetcher.withSearchTerm(searchTerm)(args);
+      const exp = {...args, description: "Foo"};
+      expect(result).toEqual(exp);
+    });    
+
+  });
+  
+});
+
+
+describe('transactionTableHeader', () => {
+
+  describe('_searchTermChangeHandler', () => {
+
+    let setSearchTerm, newSearchTerm, event, result;
+
+    beforeEach(() => {
+      newSearchTerm = "Foo";
+      setSearchTerm = sinon.fake();
+      event = {
+        preventDefault: sinon.fake(),
+        target: {value: newSearchTerm}
+      };
+      result = sut.transactionTableHeader._searchTermChangeHandler(setSearchTerm, event);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('Calls event.preventDefault', () => {
+      expect(event.preventDefault.calledOnceWith()).toBe(true);
+    });
+
+    it('Calls setSearchTerm', () => {
+      expect(setSearchTerm.calledOnceWith(newSearchTerm)).toBe(true);
+    });
+    
+  });
+
+  describe('genElement', () => {
+
+    let searchTermState, opts, component, searchTermChangeHandlerMock, curriedSearchTermHandler;
+
+    beforeEach(() => {
+      curriedSearchTermHandler = sinon.fake();
+      searchTermState = ["Foo", sinon.fake()];
+      opts = {searchTermState};
+      searchTermChangeHandlerMock = sinon.stub(
+        sut.transactionTableHeader,
+        '_searchTermChangeHandler'
+      ).returns(curriedSearchTermHandler);
+      component = mount(sut.transactionTableHeader.genElement(opts));
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('Renders a form with onSubmit', () => {
+      expect(typeof component.find("form").props().onSubmit).toEqual("function");
+    });
+
+    it('Renders a div with correct classname', () => {
+      expect(component.find("div.transaction-table-header")).toHaveLength(1);
+    });
+
+    it('Renders an input for user to enter text', () => {
+      const input = component.find("input.transaction-table-header__input");
+      expect(input).toHaveLength(1);
+      expect(input.instance().placeholder).toEqual("SearchTerm");
+      expect(input.instance().type).toEqual("text");
+      expect(input.props().value).toEqual("Foo");
+      expect(input.props().onChange).toEqual(curriedSearchTermHandler);
+    });
+
+    it('Calls searchTermChangeHandler with setSearchTerm', () => {
+      expect(searchTermChangeHandlerMock.calledOnceWith(searchTermState[1])).toBe(true);
+    });
+
+    it('Renders a button for the user to submit', () => {
+      const button = component.find("button.transaction-table-header__button");
+      expect(button).toHaveLength(1);
     });
     
   });

--- a/src/css/components/_transaction-table.scss
+++ b/src/css/components/_transaction-table.scss
@@ -1,0 +1,12 @@
+.transaction-table-header {
+
+    margin-bottom: 5px;
+
+    &__input {
+        width: 450px;
+    }
+
+    &__button {
+        margin-left: 5px;
+    }
+}


### PR DESCRIPTION
Adds functionality to search a transaction based on a string search
term, which is searched inside the `Description` of the existing
transactions.

Moves the ReactTable into a more controlled component so we can
properly reset the page when fetching for new transactions with a
search term.

Corrects some tests that were missing `act`.